### PR TITLE
Fix for ie11

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "keywords": [],
   "dependencies": {
     "cross-fetch": "^2.2.2",
-    "lru-cache": "^4.1.3"
+    "quick-lru": "^2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/httpRangeFetcher.js
+++ b/src/httpRangeFetcher.js
@@ -1,4 +1,4 @@
-const LRU = require('lru-cache')
+const LRU = require('quick-lru')
 
 const { CacheSemantics } = require('./cacheSemantics')
 const AggregatingFetcher = require('./aggregatingFetcher')
@@ -39,9 +39,9 @@ class HttpRangeFetcher {
       maxExtraSize: maxExtraFetch,
     })
     this.chunkSize = chunkSize
-    this.chunkCache = LRU({ max: Math.floor(size / chunkSize) })
+    this.chunkCache = new LRU({ maxSize: Math.floor(size / chunkSize) || 1 })
     this.cacheSemantics = new CacheSemantics({ minimumTTL })
-    this.stats = LRU({ max: 20 })
+    this.stats = new LRU({ maxSize: 20 })
   }
 
   /**

--- a/src/httpRangeFetcher.js
+++ b/src/httpRangeFetcher.js
@@ -236,8 +236,8 @@ class HttpRangeFetcher {
    * Throw away all cached data, resetting the cache.
    */
   reset() {
-    this.stats.reset()
-    this.chunkCache.reset()
+    this.stats.clear()
+    this.chunkCache.clear()
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3856,7 +3856,7 @@ lowercase-keys@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
 
-lru-cache@^4.0.1, lru-cache@^4.1.3:
+lru-cache@^4.0.1:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
   dependencies:
@@ -4778,6 +4778,11 @@ query-string@^5.0.1:
     decode-uri-component "^0.2.0"
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
+
+quick-lru@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-2.0.0.tgz#32b017b28d1784631c8ab0a1ed2978e094dbe181"
+  integrity sha512-DqOtZziv7lDjEyuqyVQacRciAwMCEjTNrLYCHYEIIgjcE/tLEpBF82hiDIwCjRnEL9/hY2GJxA0T8ZvYvVVSSA==
 
 randomatic@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This changes to use quick-lru which aids IE11 compatibility because lru-cache uses Object.defineProperty on length which seems un-babel-ifiable