### PR TITLE
Correct cache delete for quick-lru

### DIFF
--- a/src/httpRangeFetcher.js
+++ b/src/httpRangeFetcher.js
@@ -228,7 +228,7 @@ class HttpRangeFetcher {
   // have been overwritten sometime while the promise was in flight
   _uncacheIfSame(key, cachedPromise) {
     if (this.chunkCache.get(key) === cachedPromise) {
-      this.chunkCache.del(key)
+      this.chunkCache.delete(key)
     }
   }
 


### PR DESCRIPTION
The switch to quick-lru needs this fix, bug was found by testing a vcftabix file