### PR TITLE
Make sure that even when retrieving a cached promise instance that the stats get set

### DIFF
--- a/src/httpRangeFetcher.js
+++ b/src/httpRangeFetcher.js
@@ -216,6 +216,8 @@ class HttpRangeFetcher {
         this._uncacheIfSame(chunkKey, cachedPromise)
         return this._getChunk(key, chunkNumber, requestOptions)
       }
+
+      this.stats.set(key, this._headersToStats(chunk))
       return chunk
     }
 


### PR DESCRIPTION
The code for stat appears to be able to get into a state where it is returning undefined for stat

This ensures that even if retrieving a cached promise, that it updates the stats cache. This seems like a bit of a race condition type thing, but essentially you can have

Request 1 for something, maybe stat- gets the freshPromise, store freshPromise in cache, await on freshPromise, update the stats cache
Request 2 for stat- gets the cached promise, await cachedPromise, stats undefined still, gives error

So there is a contention where the await cachedPromise might finish before await freshPromise finished and then we get a stats undefined error


