### PR TITLE
Move standard-changelog to devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "abortcontroller-polyfill": "^1.2.9",
     "cross-fetch": "^2.2.2",
     "object.entries-ponyfill": "^1.0.1",
-    "quick-lru": "^2.0.0",
-    "standard-changelog": "^1.0.0"
+    "quick-lru": "^2.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",
@@ -65,7 +64,8 @@
     "npm-watch": "^0.5.0",
     "opn-cli": "^3.1.0",
     "prettier": "^1.11.1",
-    "rimraf": "^2.6.2"
+    "rimraf": "^2.6.2",
+    "standard-changelog": "^1.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Produces warnings on npm install in downstream stuff about sprintf being deprecated or similar, but is not needed in the downstream